### PR TITLE
fix: different checks

### DIFF
--- a/R/mutateDS.R
+++ b/R/mutateDS.R
@@ -30,17 +30,18 @@ mutateDS <- function(tidy_expr, df.name, .keep = NULL, .before = NULL, .after = 
 
 #' @title Check for Disallowed Character in ds.mutate
 #' @description This internal function checks whether the provided expression contains a colon (`:`),
-#' which is not permitted in `ds.mutate`. If a colon is found, the function throws an error.
+#' which is not permitted in `ds.mutate`. If a colon or letter 'c' is found, the function throws an error.
 #' @param tidy_expr A character string representing the expression to be checked.
 #' @return This function does not return a value; it throws an error if `tidy_expr` contains `:`.
 #' @importFrom cli cli_abort
 #' @keywords internal
 #' @noRd
 .check_mutate_disclosure <- function(tidy_expr){
-  if(grepl(":", tidy_expr)){
+  matches <- regmatches(tidy_expr, gregexpr("(:|c)", tidy_expr))[[1]]
+  if (length(matches) > 0) {
     cli_abort(
       c(
-        "x" = "It is not permitted to use the character ':' within ds.mutate.",
+        "x" = "It is not permitted to use the character{?s} '{matches}' within ds.mutate.",
         "i" = "You passed the expression '{tidy_expr}'.",
         "i" = "Please remove this character and try again."
       )

--- a/R/mutateDS.R
+++ b/R/mutateDS.R
@@ -37,7 +37,7 @@ mutateDS <- function(tidy_expr, df.name, .keep = NULL, .before = NULL, .after = 
 #' @keywords internal
 #' @noRd
 .check_mutate_disclosure <- function(tidy_expr){
-  matches <- regmatches(tidy_expr, gregexpr("(:|c)", tidy_expr))[[1]]
+  matches <- regmatches(tidy_expr, gregexpr("(:|c\\()", tidy_expr))[[1]]
   if (length(matches) > 0) {
     cli_abort(
       c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -175,7 +175,7 @@ listPermittedTidyverseFunctionsDS <- function() {
       "matches", "num_range", "all_of", "any_of", "where", "rename", "mutate", "if_else",
       "case_when", "mean", "median", "mode", "desc", "last_col", "nth", "where", "num_range",
       "exp", "sqrt", "scale", "round", "floor", "ceiling", "abs", "sd", "var",
-      "sin", "cos", "tan", "asin", "acos", "atan"
+      "sin", "cos", "tan", "asin", "acos", "atan", "c"
     )
   )
 }

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -17,7 +17,7 @@
     Condition
       Error:
       ! Values passed to `expr` may only contain permitted functions.
-      i Permitted functions are everything, last_col, group_cols, starts_with, ends_with, contains, matches, num_range, all_of, any_of, where, rename, mutate, if_else, case_when, mean, median, mode, ..., acos, and atan.
+      i Permitted functions are everything, last_col, group_cols, starts_with, ends_with, contains, matches, num_range, all_of, any_of, where, rename, mutate, if_else, case_when, mean, median, mode, ..., atan, and c.
       i `filter and slice` are not permitted functions.
 
 # .check_variable_length blocks variables with value greater than than nfilter.string
@@ -49,7 +49,7 @@
     Condition
       Error:
       ! Values passed to `expr` may only contain permitted functions.
-      i Permitted functions are everything, last_col, group_cols, starts_with, ends_with, contains, matches, num_range, all_of, any_of, where, rename, mutate, if_else, case_when, mean, median, mode, ..., acos, and atan.
+      i Permitted functions are everything, last_col, group_cols, starts_with, ends_with, contains, matches, num_range, all_of, any_of, where, rename, mutate, if_else, case_when, mean, median, mode, ..., atan, and c.
       i `filter and slice` are not permitted functions.
 
 # .tidy_disclosure_checks blocks argument with single unpermitted function name
@@ -59,6 +59,6 @@
     Condition
       Error:
       ! Values passed to `expr` may only contain permitted functions.
-      i Permitted functions are everything, last_col, group_cols, starts_with, ends_with, contains, matches, num_range, all_of, any_of, where, rename, mutate, if_else, case_when, mean, median, mode, ..., acos, and atan.
+      i Permitted functions are everything, last_col, group_cols, starts_with, ends_with, contains, matches, num_range, all_of, any_of, where, rename, mutate, if_else, case_when, mean, median, mode, ..., atan, and c.
       i `slice` is not a permitted function.
 

--- a/tests/testthat/test-mutateDS.R
+++ b/tests/testthat/test-mutateDS.R
@@ -89,38 +89,49 @@ test_that("mutateDS passes when called directly", {
 })
 
 test_that("mutateDS doesn't work with banned function calls that could create a vector", {
-  banned_arg_1 <- "mutate(banned = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32))"
+  banned_arg_1 <- "banned = row_number()"
   expect_error(
     .check_tidy_disclosure("mtcars", banned_arg_1),
-    "`c` is not a permitted function")
-
-  banned_arg_2 <- "mutate(banned = row_number())"
-  expect_error(
-    .check_tidy_disclosure("mtcars", banned_arg_2),
     "`row_number` is not a permitted function")
 
-  banned_arg_3 <- "mutate(banned = seq(1, 32, 1))"
+  banned_arg_2 <- "banned = seq(1, 32, 1)"
   expect_error(
-    .check_tidy_disclosure("mtcars", banned_arg_3),
+    .check_tidy_disclosure("mtcars", banned_arg_2),
     "`seq` is not a permitted function")
 
-  banned_arg_4 <- "mutate(banned = rep(1, 32))"
+  banned_arg_3 <- "banned = rep(1, 32)"
   expect_error(
-    .check_tidy_disclosure("mtcars", banned_arg_4),
+    .check_tidy_disclosure("mtcars", banned_arg_3),
     "`rep` is not a permitted function")
 })
 
 test_that(".check_mutate_disclosure blocks the use of ':'", {
-  banned_arg_1 <- "mutate(banned = 1:32)"
+  banned_arg_4 <- "banned = 1:32"
   expect_error(
-    .check_mutate_disclosure(banned_arg_1),
+    .check_mutate_disclosure(banned_arg_4),
     "It is not permitted to use the character ':' within ds.mutate."
   )
 })
 
+test_that(".check_mutate_disclosure blocks the use of 'c'", {
+  banned_arg_5 <- "banned = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32)"
+  expect_error(
+    .check_mutate_disclosure(banned_arg_5),
+    "It is not permitted to use the character 'c' within ds.mutate")
+})
+
+test_that(".check_mutate_disclosure blocks the use of both 'c' and ':'", {
+  banned_arg_6 <- "banned = c(1, 2, 3) + 1:32"
+  expect_error(
+    .check_mutate_disclosure(banned_arg_6),
+    "It is not permitted to use the characters 'c and :' within ds.mutate")
+})
+
 test_that(".check_mutate_disclosure doesn't block permitted strings", {
-  good_arg_1 <- "mutate(ok^2)"
+  good_arg_1 <- "ok^2"
   expect_silent(
     .check_mutate_disclosure(good_arg_1)
   )
 })
+
+

--- a/tests/testthat/test-selectDS.R
+++ b/tests/testthat/test-selectDS.R
@@ -58,3 +58,10 @@ test_that("select passes when called directly", {
     c("mpg", "drat", "wt")
   )
 })
+
+test_that("select passes strings that included 'c'", {
+  good_arg_1 <- "any_of(c(mpg, cyl, drat))"
+  expect_silent(
+    .check_tidy_disclosure("mtcars", good_arg_1)
+  )
+})


### PR DESCRIPTION
## The problem
- Previously there was a utility function that checked for unpermitted characters being passed.
- In the previous PR, I blocked the use of 'c', because it can be used within mutate to create a sequence of numbers that could be potentially be used in an inference attack
- Unfortunately this had the unwanted behaviour of blocking operations in `select` which are not dangerous. I only realised this when tests in the clientside package broke.

## What I've done
- Now I allow 'c' to be pass the check in the utility file (unbreaking ds.select)
- Added additional check specifically within the `mutate` function to check and block the use of 'c'
- Added tests to capture both of these scenarios