### PR TITLE
fix: regex false-positive on function names like as.numeric

### DIFF
--- a/R/mutateDS.R
+++ b/R/mutateDS.R
@@ -37,7 +37,7 @@ mutateDS <- function(tidy_expr, df.name, .keep = NULL, .before = NULL, .after = 
 #' @keywords internal
 #' @noRd
 .check_mutate_disclosure <- function(tidy_expr){
-  matches <- regmatches(tidy_expr, gregexpr("(:|c\\()", tidy_expr))[[1]]
+  matches <- regmatches(tidy_expr, gregexpr("(:|(?<![A-Za-z0-9_.])c\\()", tidy_expr, perl = TRUE))[[1]]
   if (length(matches) > 0) {
     cli_abort(
       c(

--- a/tests/testthat/test-mutateDS.R
+++ b/tests/testthat/test-mutateDS.R
@@ -166,4 +166,7 @@ test_that(".check_mutate_disclosure doesn't block permitted strings", {
   )
 })
 
-
+test_that(".check_mutate_disclosure doesn't false-positive on function names ending in c", {
+  expect_silent(.check_mutate_disclosure("new_col = as.numeric(mpg)"))
+  expect_silent(.check_mutate_disclosure("new_col = as.numeric(as.Date(date_str))"))
+})


### PR DESCRIPTION
## Background
In PR #89 we allowed `as.numeric` to be used within `ds.mutate`. However, this was not tested properly and never worked, because it was blocked by the regex due to the ending `c(` (`c` is not a permitted function).

## What's changed
The regex has been extended to only block `c(` when it is not immediately preceded by other characters.

## How to test
- [ ] review code
- [ ] Check CI is green