### PR TITLE
fix: remove nth from permitted functions list

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -172,7 +172,7 @@ listPermittedTidyverseFunctionsDS <- function() {
   defaultFunctions <- c(
     "everything", "last_col", "group_cols", "starts_with", "ends_with", "contains",
     "matches", "num_range", "all_of", "any_of", "where", "rename", "mutate", "if_else",
-    "case_when", "mean", "median", "mode", "desc", "last_col", "nth", "where", "num_range",
+    "case_when", "mean", "median", "mode", "desc", "last_col", "where", "num_range",
     "exp", "sqrt", "scale", "round", "floor", "ceiling", "abs", "sd", "var",
     "sin", "cos", "tan", "asin", "acos", "atan", "c", "as.character", "as.integer", "as.numeric",
     "lag", "diff", "cumsum", "is.na", "as.Date"

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -388,7 +388,7 @@ test_that(".listPermittedTidyverseFunctionsDS returns correct default function l
     c(
       "everything", "last_col", "group_cols", "starts_with", "ends_with", "contains",
       "matches", "num_range", "all_of", "any_of", "where", "rename", "mutate", "if_else",
-      "case_when", "mean", "median", "mode", "desc", "last_col", "nth", "where", "num_range",
+      "case_when", "mean", "median", "mode", "desc", "last_col", "where", "num_range",
       "exp", "sqrt", "scale", "round", "floor", "ceiling", "abs", "sd", "var",
       "sin", "cos", "tan", "asin", "acos", "atan", "c", "as.character", "as.integer", "as.numeric",
       "lag", "diff", "cumsum", "is.na", "as.Date"


### PR DESCRIPTION
## Background
In PR #89 we allowed `nth` to be used in `ds.mutate`. On reflection this carries a disclosure risk so I think it should be removed.

## What is changed
`nth` is no longer permitted by the tidyverse encode dictionary.

## How to test
- [ ] Code review
- [ ] Check CI is green