### PR TITLE
feat: add % to encoding dictionary as $PCT$

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -5,10 +5,10 @@
 #' @noRd
 .get_encode_dictionary <- function() {
   encode_list <- list(
-    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
+    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n", "%"),
     output = c(
       "$LB$", "$RB$", "$QUOTE$", "$COMMA$", "$SPACE$", "$EXCL$", "$AND$", "$OR$",
-      "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$"
+      "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$", "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$", "$PCT$"
     )
   )
   return(encode_list)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -142,10 +142,10 @@ test_that(".tidy_eval_handle_errors fails with correct message when unrecognised
 
 test_that(".get_encode_dictionary returns the expected encoding key", {
   expected_encode_list <- list(
-    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n"),
+    input = c("(", ")", "\"", ",", " ", "!", "&", "|", "'", "=", "+", "-", "*", "/", "^", ">", "<", "~", "\n", "%"),
     output = c(
       "$LB$", "$RB$", "$QUOTE$", "$COMMA$", "$SPACE$", "$EXCL$", "$AND$", "$OR$", "$APO$", "$EQU$", "$ADD$", "$SUB$", "$MULT$",
-      "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$"
+      "$DIVIDE$", "$POWER$", "$GT$", "$LT$", "$TILDE$", "$LINE$", "$PCT$"
     )
   )
   actual_encode_list <- .get_encode_dictionary()


### PR DESCRIPTION
## Background
In PR #94 we allowed `as.Date` to be passed to `ds.mutate`. However, to be able to use effectively we also need to be able to specify a date format, which is done in the second argument to `as.Date`. In order to do this, we need the client to be able to pass the symbol `%`, e.g. 'as.Date(x, "%Y-%m-%d")'.

## What's changed
Modified the tidyverse encoder to allow `%` to pass.

## How to test
- [ ] Review code
- [ ] Check CI is green