### PR TITLE
fix: tag release after version bump commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,9 @@ jobs:
           if [  $CIRCLE_BRANCH = "master" ] && [ $PREVIOUS != $NEXT  ]; then
             echo "Releasing ${PACKAGE}:${TAG}, pushing to git"
 
+            git commit -a -m 'Increment DESCRIPTION number'
             git tag v${TAG}
             git push --tags origin master
-            git commit -a -m 'Increment DESCRIPTION number'
-            git push origin master
 
             response=$(curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/molgenis/ds-tidyverse/releases \


### PR DESCRIPTION
## Background 
The CircleCI release step had a bug where it created the git tag before committing the version bump to DESCRIPTION. This meant release tags (e.g. v1.2.1) pointed to commits that still contained the old version number in DESCRIPTION, rather than the commit with the actual new version.                                                                                                                                                                   
                                                                                                                                                                                                                                        
## What changed
Reordered the release step so the version bump is committed first, then the tag is applied to that commit. This ensures the tag always points to a commit where DESCRIPTION matches the tagged version.                 
               
## How to test
Unfortunately no way to test other than by merging to master. Code review, then if you approve I'll merge and see if it works?